### PR TITLE
Fixed incorrect apostrophe character in podspec

### DIFF
--- a/iLink.podspec
+++ b/iLink.podspec
@@ -8,6 +8,6 @@ Pod::Spec.new do |s|
   s.source   = { :git => 'https://github.com/sidan5/iLink.git', :tag => '1.0' }
   s.source_files = 'iLink/iLink.{h,m}'
   s.requires_arc = true
-  s.ios.deployment_target = ‘5.1’
-  s.osx.deployment_target = '10.7’
+  s.ios.deployment_target = '5.1'
+  s.osx.deployment_target = '10.7'
 end


### PR DESCRIPTION
The old podspec causes a crash in cocoapods